### PR TITLE
fix: include session_id claim in OAuth access tokens for proper logout

### DIFF
--- a/api/internal/auth/domain/service.go
+++ b/api/internal/auth/domain/service.go
@@ -52,7 +52,7 @@ type Service interface {
 type TokenDomainService interface {
 	RefreshToken(ctx context.Context, session *Session, user *User) (*Claims, error)
 	ValidateRefreshEligibility(session *Session) error
-	CreateSession(userID, refreshToken, deviceID, clientIP, userAgent string) (*Session, error)
+	CreateSession(sessionID, userID, refreshToken, deviceID, clientIP, userAgent string) (*Session, error)
 	ValidateTokenClaims(claims *Claims) error
 	ShouldRefreshToken(claims *Claims) bool
 }

--- a/api/internal/auth/domain/token_domain_service.go
+++ b/api/internal/auth/domain/token_domain_service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 )
 
 // tokenDomainService implements business rules for token management
@@ -69,11 +68,11 @@ func (s *tokenDomainService) ValidateRefreshEligibility(session *Session) error 
 }
 
 // CreateSession creates a new session with proper business rules
-func (s *tokenDomainService) CreateSession(userID, refreshToken, deviceID, clientIP, userAgent string) (*Session, error) {
+func (s *tokenDomainService) CreateSession(sessionID, userID, refreshToken, deviceID, clientIP, userAgent string) (*Session, error) {
 	now := time.Now()
 	
 	session := &Session{
-		ID:           uuid.NewString(),
+		ID:           sessionID,
 		UserID:       userID,
 		RefreshToken: refreshToken,
 		DeviceID:     deviceID,


### PR DESCRIPTION
### Why
OAuth access tokens were missing session_id claims, causing logout issues where tokens remained valid until expiration instead of being properly invalidated when sessions were revoked.

### What I did
- Modified `HandleCallback` function to generate sessionID first and pass it to `CreateSession`
- Changed `generateTokenPair` function from variadic args to explicit `sessionID string` parameter
- Updated `TokenDomainService.CreateSession` to accept sessionID as first parameter
- Added comprehensive tests to verify session_id inclusion in JWT tokens
- Updated all mock interfaces to match new function signatures

### Note (if anything to write)
All tests pass and the implementation follows the requested approach of generating sessionID before token creation and passing it through the session creation flow.