### PR TITLE
Fix: Save all fields when creating Organization

### DIFF
--- a/api/internal/organization/repository/models.go
+++ b/api/internal/organization/repository/models.go
@@ -2,17 +2,25 @@ package repository
 
 import (
 	"time"
+
 	"github.com/hexabase/hexabase-ai/api/internal/organization/domain"
 )
 
 // dbOrganization represents the database model for organizations
 type dbOrganization struct {
-	ID                   string    `gorm:"primaryKey"`
-	Name                 string    `gorm:"not null"`
-	StripeCustomerID     *string   `gorm:"unique"`
-	StripeSubscriptionID *string   `gorm:"unique"`
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                   string     `gorm:"primaryKey"`
+	Name                 string     `gorm:"not null"`
+	DisplayName          string     `gorm:"column:display_name"`
+	Description          string     `gorm:"column:description"`
+	Website              string     `gorm:"column:website"`
+	Email                string     `gorm:"column:email"`
+	Status               string     `gorm:"column:status;default:'active'"`
+	OwnerID              string     `gorm:"column:owner_id"`
+	StripeCustomerID     *string    `gorm:"unique"`
+	StripeSubscriptionID *string    `gorm:"unique"`
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	DeletedAt            *time.Time `gorm:"column:deleted_at"`
 }
 
 func (dbOrganization) TableName() string {
@@ -35,10 +43,17 @@ func (dbOrganizationUser) TableName() string {
 
 func domainToDBOrganization(org *domain.Organization) *dbOrganization {
 	return &dbOrganization{
-		ID:        org.ID,
-		Name:      org.Name,
-		CreatedAt: org.CreatedAt,
-		UpdatedAt: org.UpdatedAt,
+		ID:                   org.ID,
+		Name:                 org.Name,
+		DisplayName:          org.DisplayName,
+		Description:          org.Description,
+		Website:              org.Website,
+		Email:                org.Email,
+		Status:               org.Status,
+		OwnerID:              org.OwnerID,
+		CreatedAt:            org.CreatedAt,
+		UpdatedAt:            org.UpdatedAt,
+		DeletedAt:            org.DeletedAt,
 	}
 }
 
@@ -46,10 +61,15 @@ func dbToDomainOrganization(dbOrg *dbOrganization) *domain.Organization {
 	return &domain.Organization{
 		ID:          dbOrg.ID,
 		Name:        dbOrg.Name,
-		DisplayName: dbOrg.Name, // Use name as display name
-		Status:      "active",   // Default status
+		DisplayName: dbOrg.DisplayName,
+		Description: dbOrg.Description,
+		Website:     dbOrg.Website,
+		Email:       dbOrg.Email,
+		Status:      dbOrg.Status,
+		OwnerID:     dbOrg.OwnerID,
 		CreatedAt:   dbOrg.CreatedAt,
 		UpdatedAt:   dbOrg.UpdatedAt,
+		DeletedAt:   dbOrg.DeletedAt,
 	}
 }
 

--- a/api/internal/shared/db/migrations/20250626063937000_add_organizations_columns.down.sql
+++ b/api/internal/shared/db/migrations/20250626063937000_add_organizations_columns.down.sql
@@ -1,0 +1,8 @@
+-- organizationsテーブルからDisplayName, Description, Website, Email, Status, OwnerID, DeletedAtを削除
+ALTER TABLE organizations DROP COLUMN IF EXISTS display_name;
+ALTER TABLE organizations DROP COLUMN IF EXISTS description;
+ALTER TABLE organizations DROP COLUMN IF EXISTS website;
+ALTER TABLE organizations DROP COLUMN IF EXISTS email;
+ALTER TABLE organizations DROP COLUMN IF EXISTS status;
+ALTER TABLE organizations DROP COLUMN IF EXISTS owner_id;
+ALTER TABLE organizations DROP COLUMN IF EXISTS deleted_at;

--- a/api/internal/shared/db/migrations/20250626063937000_add_organizations_columns.up.sql
+++ b/api/internal/shared/db/migrations/20250626063937000_add_organizations_columns.up.sql
@@ -1,0 +1,10 @@
+-- organizationsテーブルにDisplayName, Description, Website, Email, Status, OwnerID, DeletedAtを追加
+ALTER TABLE organizations ADD COLUMN display_name VARCHAR(255);
+ALTER TABLE organizations ADD COLUMN description TEXT;
+ALTER TABLE organizations ADD COLUMN website VARCHAR(255);
+ALTER TABLE organizations ADD COLUMN email VARCHAR(255);
+ALTER TABLE organizations ADD COLUMN status VARCHAR(32) DEFAULT 'active';
+ALTER TABLE organizations ADD COLUMN owner_id VARCHAR(64);
+ALTER TABLE organizations ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE NULL;
+-- statusカラムのデフォルト値をactiveに設定
+ALTER TABLE organizations ALTER COLUMN status SET DEFAULT 'active';


### PR DESCRIPTION
### Why
Previously, only the `name` field was saved to the `organizations` table when creating an Organization via POST /organizations, even though the API accepts `name`, `display_id`, `description`, `website`, and `email`. This caused loss of important organization information.

### What I did
- Modified the implementation so that `display_id`, `description`, `website`, and `email` are also saved to the `organizations` table when creating an Organization.
- Updated the entity, repository, and handler logic to handle all fields from the request.
- Added or updated migration files as needed.